### PR TITLE
go fullscreen when game starts, tweak position of metadata info

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -199,11 +199,13 @@ function onStoryClicked() {
 
 function onGameClicked() {
     hide( ["main", "about", "gollstory"]);
+    openFullscreen();
     ready();
     show("game");
 }
 
 function onMainClicked() {
+    closeFullscreen();
     hide( ["game", "about", "gollstory"]);
     show("main");
 
@@ -302,4 +304,31 @@ function getStats()
 
     elem.innerHTML = text;
 
+}
+
+/* View in fullscreen */
+function openFullscreen() {
+  let elem = document.documentElement;
+  if (elem.requestFullscreen) {
+    elem.requestFullscreen();
+  } else if (elem.mozRequestFullScreen) { /* Firefox */
+    elem.mozRequestFullScreen();
+  } else if (elem.webkitRequestFullscreen) { /* Chrome, Safari and Opera */
+    elem.webkitRequestFullscreen();
+  } else if (elem.msRequestFullscreen) { /* IE/Edge */
+    elem.msRequestFullscreen();
+  }
+}
+
+/* Close fullscreen */
+function closeFullscreen() {
+  if (document.exitFullscreen) {
+    document.exitFullscreen();
+  } else if (document.mozCancelFullScreen) { /* Firefox */
+    document.mozCancelFullScreen();
+  } else if (document.webkitExitFullscreen) { /* Chrome, Safari and Opera */
+    document.webkitExitFullscreen();
+  } else if (document.msExitFullscreen) { /* IE/Edge */
+    document.msExitFullscreen();
+  }
 }

--- a/styles/goll.css
+++ b/styles/goll.css
@@ -512,7 +512,7 @@ video {
 }
 
 .level {
-    font-size: calc(12px + 1.5vw);
+    font-size: calc(12px + 0.75vw);
     position:absolute;
     bottom:0%;
     right:0%;
@@ -685,7 +685,7 @@ video {
     padding-right: 1vw;
     display:block;
     margin:auto;
-    width:55vh;   
+    width:22vw;
 }
 
 .large-screen {
@@ -875,7 +875,7 @@ video {
 }
 */
 
-@media only screen and (orientation: landscape) and (max-width: 1480px)
+@media only screen and (orientation: landscape) and (max-width:1024px)
 {
     .goll-container {
         display: none;
@@ -950,8 +950,8 @@ video {
         font-size:1.25vw;
     }
 
-    #metadata-container {
-        display:none;
+    .metadata-container {
+        width: 16vw;
     }
 
     .cheat-action, .skip-action {
@@ -960,7 +960,7 @@ video {
 }
 
 
-@media only screen and (orientation: landscape) and (min-width: 1480px)
+@media only screen and (orientation: landscape) and (min-width: 1024px)
 {
     .goll-container {
         display: none;
@@ -1001,6 +1001,7 @@ video {
     .large-screen {
         width:23vh;
     }
+
 }
 
 @media only screen and (orientation: portrait)


### PR DESCRIPTION
- Go fullscreen when game starts (works better on tablets)
- Reduce widget size for metadata for all resolutions in landscape